### PR TITLE
Refactor : 존재하지 않는 질문ID를 입력한 경우 예외처리

### DIFF
--- a/src/main/java/com/tecst/tecst/domain/bookmark/mapper/BookmarkMapper.java
+++ b/src/main/java/com/tecst/tecst/domain/bookmark/mapper/BookmarkMapper.java
@@ -3,6 +3,7 @@ package com.tecst.tecst.domain.bookmark.mapper;
 import com.tecst.tecst.domain.bookmark.dto.request.RegistBookmarkRequestDto;
 import com.tecst.tecst.domain.bookmark.entity.Bookmark;
 import com.tecst.tecst.domain.bookmark.repository.BookmarkRepository;
+import com.tecst.tecst.domain.common_question.exception.QuestionNotFound;
 import com.tecst.tecst.domain.common_question.repository.CommonQuestionRepository;
 import com.tecst.tecst.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class BookmarkMapper {
 
     public Bookmark toEntity(RegistBookmarkRequestDto dto) {
         Bookmark bookmark = Bookmark.builder().user(userRepository.findByUserId(dto.getUserId()))
-                .commonQuestion(commonQuestionRepository.findByCommonQuestionId(dto.getCommonQuestionId())).build();
+                .commonQuestion(commonQuestionRepository.findByCommonQuestionId(dto.getCommonQuestionId()).orElseThrow(QuestionNotFound::new)).build();
         return bookmark;
     }
 }

--- a/src/main/java/com/tecst/tecst/domain/common_question/controller/CommonQuestionController.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/controller/CommonQuestionController.java
@@ -2,6 +2,7 @@ package com.tecst.tecst.domain.common_question.controller;
 import com.tecst.tecst.domain.common_question.dto.response.GetCommonQuestionsResponseDto;
 import com.tecst.tecst.domain.common_question.dto.response.GetCommonQuestionsSolutionDto;
 import com.tecst.tecst.domain.common_question.entity.CommonQuestion;
+import com.tecst.tecst.domain.common_question.enumeration.Type;
 import com.tecst.tecst.domain.common_question.service.CommonQuestionService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -20,7 +21,7 @@ public class CommonQuestionController {
 
     @ApiOperation(value = "선택한 분야의 질문 제공")
     @GetMapping("/questions")
-    public GetCommonQuestionsResponseDto GetCommonQuestion(@RequestParam String type,
+    public GetCommonQuestionsResponseDto GetCommonQuestion(@RequestParam Type type,
                                                            @RequestParam int count) {
 
         return commonQuestionService.GetQuestions(type, count);

--- a/src/main/java/com/tecst/tecst/domain/common_question/dto/response/GetCommonQuestionsResponseDto.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/dto/response/GetCommonQuestionsResponseDto.java
@@ -1,5 +1,6 @@
 package com.tecst.tecst.domain.common_question.dto.response;
 
+import com.tecst.tecst.domain.common_question.enumeration.Type;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class GetCommonQuestionsResponseDto {
-    private String type;
+    private Type type;
     private int count;
     private List<CommonQuestionResponseDto> questions_list;
 

--- a/src/main/java/com/tecst/tecst/domain/common_question/entity/CommonQuestion.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/entity/CommonQuestion.java
@@ -3,6 +3,7 @@ package com.tecst.tecst.domain.common_question.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tecst.tecst.domain.answer.entity.Answer;
 import com.tecst.tecst.domain.bookmark.entity.Bookmark;
+import com.tecst.tecst.domain.common_question.enumeration.Type;
 import com.tecst.tecst.domain.user.entity.User;
 import lombok.*;
 
@@ -23,9 +24,8 @@ public class CommonQuestion {
     @GeneratedValue
     private Long commonQuestionId;
 
-//    @Enumerated(EnumType.STRING)
-    @Column(name = "Type", length = 30)
-    private String type;
+    @Enumerated(EnumType.STRING)
+    private Type type;
 
     @Column(name = "Response", length = 500)
     private String response;
@@ -41,7 +41,7 @@ public class CommonQuestion {
     private List<Answer> answers = new ArrayList<Answer>();
 
     @Builder
-    private CommonQuestion(String type, String response, String contents) {
+    private CommonQuestion(Type type, String response, String contents) {
         this.type = type;
         this.response = response;
         this.contents = contents;

--- a/src/main/java/com/tecst/tecst/domain/common_question/enumeration/Type.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/enumeration/Type.java
@@ -1,5 +1,5 @@
 package com.tecst.tecst.domain.common_question.enumeration;
 
 public enum Type {
-    os, algorithm, network, web, architecture, language
+    os, algorithm, network, web, architecture, language, all
 }

--- a/src/main/java/com/tecst/tecst/domain/common_question/exception/QuestionNotFound.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/exception/QuestionNotFound.java
@@ -1,0 +1,10 @@
+package com.tecst.tecst.domain.common_question.exception;
+
+import com.tecst.tecst.global.error.ErrorCode;
+import com.tecst.tecst.global.error.exception.BusinessException;
+
+public class QuestionNotFound extends BusinessException {
+    public QuestionNotFound() {
+        super(ErrorCode.QUESTIONS_NOT_FOUND_ERROR);
+    }
+}

--- a/src/main/java/com/tecst/tecst/domain/common_question/repository/CommonQuestionRepository.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/repository/CommonQuestionRepository.java
@@ -2,6 +2,7 @@ package com.tecst.tecst.domain.common_question.repository;
 
 import com.tecst.tecst.domain.common_question.dto.response.CommonQuestionResponseDto;
 import com.tecst.tecst.domain.common_question.entity.CommonQuestion;
+import com.tecst.tecst.domain.common_question.enumeration.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,12 +13,12 @@ import java.util.UUID;
 
 public interface CommonQuestionRepository extends JpaRepository<CommonQuestion, UUID> {
 
-    @Query(value = "select distinct * from common_question where type = :type order by rand() limit :count", nativeQuery = true)
-    List<CommonQuestionResponseDto> findCommonQuestionsByType(String type, int count);
+    @Query(value = "select distinct * from common_question where type = :#{#type.name()} order by rand() limit :count", nativeQuery = true)
+    List<CommonQuestionResponseDto> findCommonQuestionsByType(Type type, int count);
 
     @Query(value = "select * from common_question order by rand() limit :count", nativeQuery = true)
-    List<CommonQuestionResponseDto> findAllByCommonQuestionIdExists(int count);
+    List<CommonQuestionResponseDto>findAllByCommonQuestionIdExists(int count);
 
 
-    CommonQuestion findByCommonQuestionId(Long id);
+    Optional<CommonQuestion> findByCommonQuestionId(Long id);
 }

--- a/src/main/java/com/tecst/tecst/domain/common_question/service/CommonQuestionService.java
+++ b/src/main/java/com/tecst/tecst/domain/common_question/service/CommonQuestionService.java
@@ -5,6 +5,7 @@ import com.tecst.tecst.domain.common_question.dto.response.GetCommonQuestionsRes
 import com.tecst.tecst.domain.common_question.dto.response.GetCommonQuestionsSolutionDto;
 import com.tecst.tecst.domain.common_question.entity.CommonQuestion;
 import com.tecst.tecst.domain.common_question.enumeration.Type;
+import com.tecst.tecst.domain.common_question.exception.QuestionNotFound;
 import com.tecst.tecst.domain.common_question.exception.QuestionTypeNotFound;
 import com.tecst.tecst.domain.common_question.repository.CommonQuestionRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +22,16 @@ import java.util.List;
 public class CommonQuestionService {
     private final CommonQuestionRepository commonQuestionRepository;
 
-    public GetCommonQuestionsResponseDto GetQuestions(String type, int count) {
+    public GetCommonQuestionsResponseDto GetQuestions(Type type, int count) {
+
         try {
-            Type.valueOf(type);
+            Type.valueOf(String.valueOf(type));
         } catch (IllegalArgumentException e) {
             throw new QuestionTypeNotFound();
         }
+
         List<CommonQuestionResponseDto> result;
-        if (type.equals("all")) result = commonQuestionRepository.findAllByCommonQuestionIdExists(count);
+        if (type.name().equals("all")) result = commonQuestionRepository.findAllByCommonQuestionIdExists(count);
         else result = commonQuestionRepository.findCommonQuestionsByType(type, count);
         GetCommonQuestionsResponseDto dto = new GetCommonQuestionsResponseDto();
         dto.setType(type);
@@ -38,11 +41,11 @@ public class CommonQuestionService {
     }
 
     public CommonQuestion findCommonQuestionById(Long id) {
-        return commonQuestionRepository.findByCommonQuestionId(id);
+        return commonQuestionRepository.findByCommonQuestionId(id).orElseThrow(QuestionNotFound::new);
     }
 
     public GetCommonQuestionsSolutionDto GetSolutions(Long id) {
-        CommonQuestion result = commonQuestionRepository.findByCommonQuestionId(id);
+        CommonQuestion result = commonQuestionRepository.findByCommonQuestionId(id).orElseThrow(QuestionNotFound::new);
         GetCommonQuestionsSolutionDto dto = new GetCommonQuestionsSolutionDto();
         dto.setCommonQuestionId(id);
         dto.setResponse(result.getResponse());

--- a/src/main/java/com/tecst/tecst/global/error/ErrorCode.java
+++ b/src/main/java/com/tecst/tecst/global/error/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(400, "U005", "이메일 중복"),
 
     // CommonQuestion
-    QUESTIONS_TYPE_NOT_FOUND_ERROR(400, "Q001", "질문 형식을 찾을 수 없음");
+    QUESTIONS_TYPE_NOT_FOUND_ERROR(400, "Q001", "질문 형식을 찾을 수 없음"),
+    QUESTIONS_NOT_FOUND_ERROR(400, "Q002", "질문을 찾을 수 없음");
 
 
     // Comment


### PR DESCRIPTION
- 존재하지 않는 common_question id(ex.113)을 입력한 경우 예외처리
- common_question 엔티티의 type 컬럼을 String에서 Type(enum)으로 변경
- GetCommonQuestion의 입력값 변경(String type -> Type type, type을 기재하는 것이 아닌 선택하는 것으로 바꿔서 테스트 과정에서 철자가 틀리는 실수를 방지하기 위함)

