### PR TITLE
이메일은 맞지만 비밀번호가 틀린 경우 예외처리

### DIFF
--- a/src/main/java/com/tecst/tecst/domain/user/exception/BadCredential.java
+++ b/src/main/java/com/tecst/tecst/domain/user/exception/BadCredential.java
@@ -1,0 +1,8 @@
+package com.tecst.tecst.domain.user.exception;
+
+import com.tecst.tecst.global.error.ErrorCode;
+import com.tecst.tecst.global.error.exception.BusinessException;
+
+public class BadCredential extends BusinessException {
+    public BadCredential() {super(ErrorCode.BAD_CREDENTIAL_ERROR);}
+}

--- a/src/main/java/com/tecst/tecst/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/tecst/tecst/domain/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByEmail(String email);
 
+    User findByEmailAndPassword(String email, String password);
+
 }

--- a/src/main/java/com/tecst/tecst/domain/user/service/UserService.java
+++ b/src/main/java/com/tecst/tecst/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.tecst.tecst.domain.auth.dto.TokenInfo;
 import com.tecst.tecst.domain.user.dto.request.CreateUserRequestDto;
 import com.tecst.tecst.domain.user.dto.request.UserLoginRequestDto;
 import com.tecst.tecst.domain.user.entity.User;
+import com.tecst.tecst.domain.user.exception.BadCredential;
 import com.tecst.tecst.domain.user.exception.EmailDuplicated;
 import com.tecst.tecst.domain.user.exception.UserNotFound;
 import com.tecst.tecst.domain.user.mapper.UserMapper;
@@ -48,6 +49,8 @@ public class UserService {
     @Transactional
     public TokenInfo login(UserLoginRequestDto dto) {
         userRepository.findByEmail(dto.getEmail()).orElseThrow(UserNotFound::new);
+        if(userRepository.findByEmailAndPassword(dto.getEmail(), dto.getPassword())==null)
+            throw new BadCredential();
         // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
         // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(dto.getEmail(), dto.getPassword());

--- a/src/main/java/com/tecst/tecst/global/error/ErrorCode.java
+++ b/src/main/java/com/tecst/tecst/global/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     USER_USERNAME_DUPLICATED(409, "U003", "회원 아이디 중복"),
     INCORRECT_EMAIL_FORMAT(400, "U004", "잘못된 이메일 형식"),
     DUPLICATED_EMAIL(400, "U005", "이메일 중복"),
+    BAD_CREDENTIAL_ERROR(400, "U006", "회원 정보가 일치하지 않음"),
 
     // CommonQuestion
     QUESTIONS_TYPE_NOT_FOUND_ERROR(400, "Q001", "질문 형식을 찾을 수 없음"),


### PR DESCRIPTION
userRepository.findByEmailAndPassword 를 사용해 입력한 아이디와 비밀번호가 일치하는 계정이 존재하는지 확인하고 없으면 예외를 던짐