### PR TITLE
feat : 점수 저장 API 구현

### DIFF
--- a/src/main/java/com/tecst/tecst/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/tecst/tecst/domain/answer/controller/AnswerController.java
@@ -1,8 +1,10 @@
 package com.tecst.tecst.domain.answer.controller;
 
 import com.tecst.tecst.domain.answer.dto.request.SaveAnswerRequestDto;
+import com.tecst.tecst.domain.answer.dto.request.SaveScoreRequestDto;
 import com.tecst.tecst.domain.answer.dto.request.SaveVoiceAnswerRequestDto;
 import com.tecst.tecst.domain.answer.dto.response.GetAnswerResponseDto;
+import com.tecst.tecst.domain.answer.dto.response.GetScoreResponseDto;
 import com.tecst.tecst.domain.answer.dto.response.GetVoiceAnswerResponseDto;
 import com.tecst.tecst.domain.answer.service.AnswerService;
 import com.tecst.tecst.global.result.ResultResponse;
@@ -17,6 +19,7 @@ import java.io.IOException;
 
 import static com.tecst.tecst.global.result.ResultCode.ANSWER_FIND_SUCCESS;
 import static com.tecst.tecst.global.result.ResultCode.REGISTER_ANSWER_SUCCESS;
+import static com.tecst.tecst.global.result.ResultCode.SCORE_REGISTRATION_SUCCESS;
 
 @Api(tags = "Answer API")
 @RestController
@@ -51,6 +54,13 @@ public class AnswerController {
     public ResponseEntity<ResultResponse> getAnswer(@PathVariable Long answersId) {
         GetAnswerResponseDto dto = answerService.getAnswer(answersId);
         return ResponseEntity.ok(ResultResponse.of(ANSWER_FIND_SUCCESS, dto));
+    }
+
+    @ApiOperation(value = "점수 저장")
+    @PostMapping("/scores")
+    public ResponseEntity<ResultResponse> SaveScore(@RequestBody SaveScoreRequestDto dto) {
+        GetScoreResponseDto responseDto = answerService.saveScore(dto);
+        return ResponseEntity.ok(ResultResponse.of(SCORE_REGISTRATION_SUCCESS, responseDto));
     }
 
 }

--- a/src/main/java/com/tecst/tecst/domain/answer/dto/request/SaveScoreRequestDto.java
+++ b/src/main/java/com/tecst/tecst/domain/answer/dto/request/SaveScoreRequestDto.java
@@ -1,0 +1,11 @@
+package com.tecst.tecst.domain.answer.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SaveScoreRequestDto {
+    private Long answerId;
+    private String feedBack;
+}

--- a/src/main/java/com/tecst/tecst/domain/answer/dto/response/GetScoreResponseDto.java
+++ b/src/main/java/com/tecst/tecst/domain/answer/dto/response/GetScoreResponseDto.java
@@ -1,0 +1,17 @@
+package com.tecst.tecst.domain.answer.dto.response;
+
+import com.tecst.tecst.domain.answer.entity.Answer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetScoreResponseDto {
+    private Long answerId;
+    private int score;
+
+    public static GetScoreResponseDto from(Answer answer){
+        return new GetScoreResponseDto(answer.getAnswerId(),
+                answer.getScore());
+    }
+}

--- a/src/main/java/com/tecst/tecst/domain/answer/entity/Answer.java
+++ b/src/main/java/com/tecst/tecst/domain/answer/entity/Answer.java
@@ -29,6 +29,9 @@ public class Answer {
     @Column(name = "answer_url", length = 100)
     private String answerURL; // URL
 
+    @Column(name = "score")
+    private int score;
+
     @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "question_id")
     private Question question;
@@ -38,4 +41,8 @@ public class Answer {
     private User user;
 
     private String feedBack; // GPT 평가
+
+    public void update(int score) {
+        this.score = score;
+    }
 }

--- a/src/main/java/com/tecst/tecst/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/tecst/tecst/domain/answer/service/AnswerService.java
@@ -4,8 +4,10 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import com.tecst.tecst.domain.answer.ClovaSpeechClient;
 import com.tecst.tecst.domain.answer.dto.request.SaveAnswerRequestDto;
+import com.tecst.tecst.domain.answer.dto.request.SaveScoreRequestDto;
 import com.tecst.tecst.domain.answer.dto.request.SaveVoiceAnswerRequestDto;
 import com.tecst.tecst.domain.answer.dto.response.GetAnswerResponseDto;
+import com.tecst.tecst.domain.answer.dto.response.GetScoreResponseDto;
 import com.tecst.tecst.domain.answer.dto.response.GetVoiceAnswerResponseDto;
 import com.tecst.tecst.domain.answer.entity.Answer;
 import com.tecst.tecst.domain.answer.exception.AnswerNotFound;
@@ -49,6 +51,20 @@ public class AnswerService {
         Answer answer = answerMapper.toEntity(dto, user, commonQuestion);
         answerRepository.save(answer);
         return answerMapper.toDto(answer);
+    }
+
+    public GetScoreResponseDto saveScore(SaveScoreRequestDto dto) {
+        String[] feedback = dto.getFeedBack().split(":|/|\\n");
+        int sc=0;
+        for(int i=0; i< feedback.length; i++){
+            if(feedback[i].equals("점수")) {
+                sc = Integer.parseInt(feedback[i + 1]);
+                break;
+            }
+        }
+        Answer answer = answerRepository.findById(dto.getAnswerId()).orElseThrow(AnswerNotFound::new);
+        answer.update(sc);
+        return GetScoreResponseDto.from(answer);
     }
 
     public GetVoiceAnswerResponseDto GetInterviewRecord(Long id) {

--- a/src/main/java/com/tecst/tecst/global/result/ResultCode.java
+++ b/src/main/java/com/tecst/tecst/global/result/ResultCode.java
@@ -28,6 +28,8 @@ public enum ResultCode {
     // answers(사용자가 입력한 정답)
     REGISTER_ANSWER_SUCCESS("A001", "응답 등록 성공"),
     ANSWER_FIND_SUCCESS("A002", "응답 찾기 성공"),
+
+    SCORE_REGISTRATION_SUCCESS("A003", "점수 등록 성공")
     ;
 
     private final String code;


### PR DESCRIPTION
- Answer테이블에 int형 score 칼럼 추가
- AnswerId와 FeedBack을 받아 split으로 \n과 :과 /을 분리자로 분리 후 "점수" 다음의 항목을 score 칼럼에 저장